### PR TITLE
모바일 우측 슬라이드 메뉴의 토글 아이콘이 360도 돌아가도록 변경

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
 			$list.animate({height:50},{step:function(step) {
 				var current = step - 50;
 				
-				$toggle.rotate(current/height * 180);
+				$toggle.rotate((2 * height - current)/height * 180);
 				
 				if (current == 0) {
 					$list.removeClass("opened");


### PR DESCRIPTION
유투브 동영상 볼때 제목부분 화살표 터치하면 360도 돌아가는데, 180도 왔다갔다 하는것보단 360도 돌아가는게 뭔가 더 재밌으면서 안정감이 들어서 그렇게 바꿔봤습니다.